### PR TITLE
Isolate linter to  in ch1 script in

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "ch1": "semistandard --fix && node ./ch1/custom-test-phase1.js && node ./ch1/custom-test-phase2.js && node ./ch1/custom-test-phase3.js"
+    "ch1": "semistandard --fix ./ch1 && node ./ch1/custom-test-phase1.js && node ./ch1/custom-test-phase2.js && node ./ch1/custom-test-phase3.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running `npm run chl1` from the project root, semistandard runs over the whole package and stops due to errors in other folders.  This change would isolate the linter to just the `ch1` tests as the book implies. Fixes #2 

Output after change:
>  aout3-samples@1.0.0 ch1 /Users/mike/projects/aout3-samples
semistandard --fix ./ch1 && node ./ch1/custom-test-phase1.js && node ./ch1/custom-test-phase2.js && node ./ch1/custom-test-phase3.js
>
> parserTest example 1 PASSED
> sum with 2 numbers should sum them up passed
> sum with multiple digit numbers should sum them up passed
> totalSoFar by Default is 0 passed
> totalSoFar after summing is bigger passed